### PR TITLE
Testando uma requisição DELETE

### DIFF
--- a/cypress/e2e/delete.api.cy.js
+++ b/cypress/e2e/delete.api.cy.js
@@ -1,0 +1,43 @@
+/// <reference types="cypress"/>
+
+describe('Deletar Dispositivo', () => {
+    it('Deletar um dispositivo', () => {
+        const body = {
+            name: 'Apple MacBook Pro 16',
+            data: {
+                year: 2020,
+                price: 1650.8,
+                'CPU model': 'Intel Core i9',
+                'Hard disk size': '2 TB',
+            },
+        };
+
+        cy.request({
+            method: 'POST',
+            url: 'https://api.restful-api.dev/objects',
+            followRedirect: false, // desativar o seguimento automático de redirecionamentos HTTP
+            body: body,
+        }).as('postDeviceResult');
+
+        cy.get('@postDeviceResult').then((response_post) => {
+            expect(response_post.status).equal(200);
+
+            // pega o resultado do cadastro para pegar o id
+            cy.request({
+                method: 'DELETE',
+                url: `https://api.restful-api.dev/objects/${response_post.body.id}`,
+                followRedirect: false, // desativar o seguimento automático de redirecionamentos HTTP
+            }).as('deleteDeviceResult');
+
+            // validações
+            cy.get('@deleteDeviceResult').then((response_delete) => {
+                // status code
+                expect(response_delete.status).equal(200);
+                // mensagem
+                expect(response_delete.body.message).equal(
+                    `Object with id = ${response_post.body.id} has been deleted.`
+                );
+            });
+        });
+    });
+});


### PR DESCRIPTION
**O que foi aprendido?**

- Criado um alias para a requisição POST;
- Utilização do comando `cy.request` para enviar dados e criar um novo recurso através de uma requisição POST;
- Armazenamento do ID do recurso criado para uso em uma requisição subsequente;
- Criação de uma requisição DELETE para remover o recurso recém-criado, utilizando o ID obtido;
- Validação do código de status da resposta para garantir que ambas as operações (POST e DELETE) foram bem-sucedidas;
- Verificação da mensagem de confirmação na resposta da requisição DELETE para assegurar que o dispositivo foi realmente deletado;
- **Princípios de Testes Automatizados:** para excluir um recurso, é necessário que ele exista previamente. Isso significa que o cenário de deleção deve incluir a criação do recurso através de uma requisição POST. No entanto, é fundamental que esse cenário de teste seja independente, não reutilizando o cenário de criação (POST) já testado anteriormente. Cada teste deve ser autônomo para garantir a confiabilidade dos resultados e facilitar a manutenção. Dependências entre testes podem introduzir fragilidades no conjunto de testes automatizados, tornando mais difícil identificar a causa de uma falha e comprometendo a robustez do processo de automação.