### PR TITLE
Testando Uma Requisição PUT ou UPDATE

### DIFF
--- a/cypress/e2e/put.api.cy.js
+++ b/cypress/e2e/put.api.cy.js
@@ -1,0 +1,67 @@
+/// <reference types="cypress"/>
+
+describe('Alterar Dispositivo', () => {
+    it('Alterar um dispositivo', () => {
+        const current_date = new Date().toISOString().slice(0, 16);
+
+        const body_post = {
+            name: 'Apple MacBook Pro 16',
+            data: {
+                year: 2020,
+                price: 1650.8,
+                'CPU model': 'Intel Core i9',
+                'Hard disk size': '2 TB',
+                owner: 'Empresa',
+            },
+        };
+
+        const body_put = {
+            name: 'Apple MacBook Pro 16 - Testando',
+            data: {
+                year: 2020,
+                price: 1650.8,
+                'CPU model': 'Intel Core i9',
+                'Hard disk size': '2 TB',
+                owner: 'Empresa Teste',
+            },
+        };
+
+        cy.request({
+            method: 'POST',
+            url: 'https://api.restful-api.dev/objects',
+            followRedirect: false, // desativar o seguimento automático de redirecionamentos HTTP
+            body: body_post,
+        }).as('postDeviceResult');
+
+        cy.get('@postDeviceResult').then((response_post) => {
+            // status code
+            expect(response_post.status).equal(200);
+            // nome
+            expect(response_post.body.name).equal(body_post.name);
+            // dono
+            expect(response_post.body.data.owner).equal(body_post.data.owner);
+            // data do registro
+            expect(response_post.body.createdAt.slice(0, 16)).equal(current_date);
+
+            //
+            cy.request({
+                method: 'PUT',
+                url: `https://api.restful-api.dev/objects/${response_post.body.id}`,
+                followRedirect: false, // desativar o seguimento automático de redirecionamentos HTTP
+                body: body_put,
+            }).as('putDeviceResult');
+
+            // validações do PUT
+            cy.get('@putDeviceResult').then((response_put) => {
+                // status code
+                expect(response_put.status).equal(200);
+                // nome
+                expect(response_put.body.name).equal(body_put.name);
+                // dono
+                expect(response_put.body.data.owner).equal(body_put.data.owner);
+                // data do registro
+                expect(response_put.body.updatedAt.slice(0, 16)).equal(current_date);
+            });
+        });
+    });
+});


### PR DESCRIPTION
**O que foi aprendido?**

- Criado um alias para a requisição POST;
- Implementação de um fluxo completo que envolve a criação (POST) e a atualização (PUT) de um recurso utilizando Cypress;
- Utilização do comando `cy.request` para enviar dados e verificar a criação de um recurso, seguido de uma requisição PUT para atualizar o mesmo recurso; 
- Armazenamento e reutilização do ID do recurso criado na resposta da requisição POST para uso na requisição PUT subsequente;
- Validação do código de status e dos dados retornados para garantir que a atualização foi realizada corretamente;
- Verificação das propriedades específicas, como `name` e `owner`, para assegurar que os dados foram alterados conforme esperado;
- Comparação das datas de criação e atualização (`createdAt` e `updatedAt`) para garantir a precisão temporal e confirmar que a atualização ocorreu no momento correto;
- **Princípios de Testes Automatizados:** para excluir um recurso, é necessário que ele exista previamente. Isso significa que o cenário de atualização deve incluir a criação do recurso através de uma requisição POST. No entanto, é fundamental que esse cenário de teste seja independente, não reutilizando o cenário de criação (POST) já testado anteriormente. Cada teste deve ser autônomo para garantir a confiabilidade dos resultados e facilitar a manutenção. Dependências entre testes podem introduzir fragilidades no conjunto de testes automatizados, tornando mais difícil identificar a causa de uma falha e comprometendo a robustez do processo de automação.