### PR TITLE
Feat/api test 6

### DIFF
--- a/cypress/e2e/delete.api.cy.js
+++ b/cypress/e2e/delete.api.cy.js
@@ -15,7 +15,7 @@ describe('Deletar Dispositivo', () => {
         cy.request({
             method: 'POST',
             url: 'https://api.restful-api.dev/objects',
-            followRedirect: false, // desativar o seguimento automático de redirecionamentos HTTP
+            failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
             body: body,
         }).as('postDeviceResult');
 
@@ -26,7 +26,7 @@ describe('Deletar Dispositivo', () => {
             cy.request({
                 method: 'DELETE',
                 url: `https://api.restful-api.dev/objects/${response_post.body.id}`,
-                followRedirect: false, // desativar o seguimento automático de redirecionamentos HTTP
+                failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
             }).as('deleteDeviceResult');
 
             // validações
@@ -38,6 +38,46 @@ describe('Deletar Dispositivo', () => {
                     `Object with id = ${response_post.body.id} has been deleted.`
                 );
             });
+        });
+    });
+
+    it('Deletar um dispositivo não existente', () => {
+        const id_not_exist = 'testando';
+
+        cy.request({
+            method: 'DELETE',
+            url: `https://api.restful-api.dev/objects/${id_not_exist}`,
+            failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
+        }).as('deleteDeviceResult');
+
+        // validações
+        cy.get('@deleteDeviceResult').then((response_delete) => {
+            // status code
+            expect(response_delete.status).equal(404);
+            // mensagem de erro
+            expect(response_delete.body.error).equal(
+                `Object with id = ${id_not_exist} doesn't exist.`
+            );
+        });
+    });
+
+    it.only('Deletar um dispositivo de ID reservado', () => {
+        const reserved_id = 7;
+
+        cy.request({
+            method: 'DELETE',
+            url: `https://api.restful-api.dev/objects/${reserved_id}`,
+            failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
+        }).as('deleteDeviceResult');
+
+        // validações
+        cy.get('@deleteDeviceResult').then((response_delete) => {
+            // status code
+            expect(response_delete.status).equal(405);
+            // mensagem de erro
+            expect(response_delete.body.error).equal(
+                `${reserved_id} is a reserved id and the data object of it cannot be deleted. You can create your own new object via POST request and try to send a DELETE request with new generated object id.`
+            );
         });
     });
 });

--- a/cypress/e2e/get.api.cy.js
+++ b/cypress/e2e/get.api.cy.js
@@ -7,7 +7,7 @@ describe('Buscar Dispositivos', () => {
         cy.request({
             method: 'GET',
             url: `https://api.restful-api.dev/objects/${device_id}`,
-            followRedirect: false, // desativar o seguimento automático de redirecionamentos HTTP
+            failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
         }).as('getDeviceResult');
 
         // validações

--- a/cypress/e2e/post.api.cy.js
+++ b/cypress/e2e/post.api.cy.js
@@ -17,7 +17,7 @@ describe('Cadastrar Dispositivo', () => {
         cy.request({
             method: 'POST',
             url: 'https://api.restful-api.dev/objects',
-            followRedirect: false, // desativar o seguimento automático de redirecionamentos HTTP
+            failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
             body: body,
         }).as('postDeviceResult');
 

--- a/cypress/e2e/put.api.cy.js
+++ b/cypress/e2e/put.api.cy.js
@@ -29,7 +29,7 @@ describe('Alterar Dispositivo', () => {
         cy.request({
             method: 'POST',
             url: 'https://api.restful-api.dev/objects',
-            followRedirect: false, // desativar o seguimento automático de redirecionamentos HTTP
+            failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
             body: body_post,
         }).as('postDeviceResult');
 
@@ -47,7 +47,7 @@ describe('Alterar Dispositivo', () => {
             cy.request({
                 method: 'PUT',
                 url: `https://api.restful-api.dev/objects/${response_post.body.id}`,
-                followRedirect: false, // desativar o seguimento automático de redirecionamentos HTTP
+                failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
                 body: body_put,
             }).as('putDeviceResult');
 


### PR DESCRIPTION
**O que foi aprendido?**

- Criado um alias para a requisição POST;
- Foi necessário criar uma requisição POST para cadastrar um novo dispositivo antes de realizar a requisição DELETE. Isso ocorre porque, para testar a exclusão de um item, primeiro precisamos garantir que o item exista, o que só pode ser feito ao criá-lo previamente com uma requisição POST;
- Utilizado `failOnStatusCode: false` para garantir que o teste não falhe automaticamente quando o status da resposta for diferente de 2xx ou 3xx, permitindo a validação de mensagens de erro em status 4xx ou 5xx;
- Implementado um cenário de teste para verificar a exclusão de um dispositivo com ID reservado, garantindo que a API retorne o status correto e a mensagem apropriada;
- Verificado que IDs reservados, como o ID 7, não podem ser deletados, reforçando a importância de tratar essas exceções em testes automatizados.