### PR TITLE
configurado a baseURL

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,9 +1,10 @@
-const { defineConfig } = require("cypress");
+const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
-  e2e: {
-    setupNodeEvents(on, config) {
-      // implement node event listeners here
+    e2e: {
+        baseUrl: 'https://api.restful-api.dev',
+        setupNodeEvents(on, config) {
+            // implement node event listeners here
+        },
     },
-  },
 });

--- a/cypress/e2e/delete.api.cy.js
+++ b/cypress/e2e/delete.api.cy.js
@@ -46,7 +46,7 @@ describe('Deletar Dispositivo', () => {
 
         cy.request({
             method: 'DELETE',
-            url: `https://api.restful-api.dev/objects/${id_not_exist}`,
+            url: `/objects/${id_not_exist}`,
             failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
         }).as('deleteDeviceResult');
 
@@ -61,12 +61,12 @@ describe('Deletar Dispositivo', () => {
         });
     });
 
-    it.only('Deletar um dispositivo de ID reservado', () => {
+    it('Deletar um dispositivo de ID reservado', () => {
         const reserved_id = 7;
 
         cy.request({
             method: 'DELETE',
-            url: `https://api.restful-api.dev/objects/${reserved_id}`,
+            url: `/objects/${reserved_id}`,
             failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
         }).as('deleteDeviceResult');
 

--- a/cypress/e2e/get.api.cy.js
+++ b/cypress/e2e/get.api.cy.js
@@ -6,7 +6,7 @@ describe('Buscar Dispositivos', () => {
 
         cy.request({
             method: 'GET',
-            url: `https://api.restful-api.dev/objects/${device_id}`,
+            url: `/objects/${device_id}`,
             failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
         }).as('getDeviceResult');
 

--- a/cypress/e2e/post.api.cy.js
+++ b/cypress/e2e/post.api.cy.js
@@ -16,7 +16,7 @@ describe('Cadastrar Dispositivo', () => {
 
         cy.request({
             method: 'POST',
-            url: 'https://api.restful-api.dev/objects',
+            url: '/objects',
             failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
             body: body,
         }).as('postDeviceResult');

--- a/cypress/e2e/put.api.cy.js
+++ b/cypress/e2e/put.api.cy.js
@@ -28,7 +28,7 @@ describe('Alterar Dispositivo', () => {
 
         cy.request({
             method: 'POST',
-            url: 'https://api.restful-api.dev/objects',
+            url: '/objects',
             failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
             body: body_post,
         }).as('postDeviceResult');
@@ -46,7 +46,7 @@ describe('Alterar Dispositivo', () => {
             //
             cy.request({
                 method: 'PUT',
-                url: `https://api.restful-api.dev/objects/${response_post.body.id}`,
+                url: `/objects/${response_post.body.id}`,
                 failOnStatusCode: false, // não falhar automaticamente em status diferentes de 2xx ou 3xx
                 body: body_put,
             }).as('putDeviceResult');


### PR DESCRIPTION
**O que foi aprendido?**

-  Adicionado `baseUrl` no arquivo `cypress.config.js` para definir a URL base das requisições, facilitando a manutenção e tornando os testes mais limpos.